### PR TITLE
Functionality: delete account

### DIFF
--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -276,16 +276,13 @@ async def delete_account(
 
     # Delete user-related data here (e.g., speeches, friendships, etc.)
     try:
-        speeches.delete(synchronize_session=False)
-
-        db.query(Speech).filter(Speech.deleted_by == user.id).update({Speech.deleted_by: None})
+        db.query(Ban).filter(Ban.user_id == user.id).delete(synchronize_session=False)
 
         db.query(Rating).filter(Rating.speech_id.in_(speeches_ids)).delete(synchronize_session=False)
         db.query(Rating).filter(Rating.rated_by == user.id).delete(synchronize_session=False)
 
         db.query(Report).filter(Report.speech_id.in_(speeches_ids)).delete(synchronize_session=False)
         db.query(Report).filter(Report.reported_by == user.id).delete(synchronize_session=False)
-        db.query(Ban).filter(Ban.user_id == user.id).delete(synchronize_session=False)
 
 
         db.query(Friendship).filter(
@@ -295,7 +292,10 @@ async def delete_account(
         db.query(UserStreak).filter(UserStreak.user_id == user.id).delete(synchronize_session=False)
 
         db.query(UserDevice).filter(UserDevice.user_id == user.id).delete(synchronize_session=False)
+
         db.query(UserInterest).filter(UserInterest.user_id == user.id).delete(synchronize_session=False)
+
+        speeches.delete(synchronize_session=False)
 
         try:
             await delete_user(supertokens_user_id)

--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -11,7 +11,7 @@ from ...db import get_db
 from ...schemas import UserResponse, UserCreate, MonthlyUserVideosResponse, VideoInfo, FriendsListResponse, FriendInfo
 from ...models import User, Friendship, UserStreak, Speech, UserDevice, UserInterest, Rating, Ban, Report
 from supertokens_python.recipe.session import SessionContainer
-from supertokens_python.syncio import delete_user
+from supertokens_python.asyncio import delete_user
 
 from ...services import EmailService, S3SecureService
 
@@ -290,7 +290,8 @@ async def delete_account(
         db.query(UserInterest).filter(UserInterest.user_id == user.id).delete(synchronize_session=False)
 
         try:
-            delete_user(supertokens_user_id)
+            await delete_user(supertokens_user_id)
+            await session.revoke_session()
         except Exception as exc:
             logger.error("Failed to delete SuperTokens user %s: %s", supertokens_user_id, exc)
             raise HTTPException(
@@ -299,6 +300,7 @@ async def delete_account(
             )
 
         user.email = f"deleted_{user.id}@deleted.local"
+        user.supertokens_user_id = f"deleted_{user.supertokens_user_id}"
         user.handle = f"deleted_{user.id}"
         user.profile_picture_url = None
         user.deleted_at = datetime.datetime.now(datetime.timezone.utc)
@@ -306,12 +308,13 @@ async def delete_account(
 
         db.commit()
 
-        return JSONResponse(
+        response = JSONResponse(
             status_code=status.HTTP_200_OK,
             content={
                 'message': 'User account deleted successfully'
             }
         )
+        return response
     
     except Exception as exc:
         logger.error("Error deleting user data for user %s: %s", user.id, exc)

--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -9,8 +9,9 @@ from sqlalchemy.orm import Session
 from ..deps import get_session, get_s3_service
 from ...db import get_db
 from ...schemas import UserResponse, UserCreate, MonthlyUserVideosResponse, VideoInfo, FriendsListResponse, FriendInfo
-from ...models import User, Friendship, UserStreak, Speech
+from ...models import User, Friendship, UserStreak, Speech, UserDevice, UserInterest, Rating, Ban, Report
 from supertokens_python.recipe.session import SessionContainer
+from supertokens_python.syncio import delete_user
 
 from ...services import EmailService, S3SecureService
 
@@ -240,3 +241,81 @@ async def get_friends_list(
             )
 
     return FriendsListResponse(friends=friend_infos)
+
+@router.delete('/delete', response_class=JSONResponse)
+async def delete_account(
+    db: Session = Depends(get_db),
+    session: SessionContainer = Depends(get_session)
+):
+    supertokens_user_id = session.get_user_id()
+
+    user: User | None = db.query(User).filter(
+        User.supertokens_user_id == supertokens_user_id
+    ).first()
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='User not found'
+        )
+    
+    # ------------------------------------ #
+    # Delete user's videos and pfp from S3 #
+    # ------------------------------------ #
+    
+
+    # Delete user-related data here (e.g., speeches, friendships, etc.)
+    try:
+        speeches = db.query(Speech).filter(Speech.user_id == user.id)
+        speeches_ids = [speech.id for speech in speeches.all()]
+        speeches.delete()
+
+        db.query(Speech).filter(Speech.deleted_by == user.id).update({Speech.deleted_by: None})
+
+        db.query(Rating).filter(Rating.speech_id.in_(speeches_ids)).delete(synchronize_session=False)
+        db.query(Rating).filter(Rating.rated_by == user.id).delete(synchronize_session=False)
+
+        db.query(Report).filter(Report.speech_id.in_(speeches_ids)).delete(synchronize_session=False)
+        db.query(Report).filter(Report.reported_by == user.id).delete(synchronize_session=False)
+        db.query(Ban).filter(Ban.user_id == user.id).delete(synchronize_session=False)
+
+
+        db.query(Friendship).filter(
+            (Friendship.user_id1 == user.id) | (Friendship.user_id2 == user.id)
+        ).delete(synchronize_session=False)
+
+        db.query(UserStreak).filter(UserStreak.user_id == user.id).delete(synchronize_session=False)
+
+        db.query(UserDevice).filter(UserDevice.user_id == user.id).delete(synchronize_session=False)
+        db.query(UserInterest).filter(UserInterest.user_id == user.id).delete(synchronize_session=False)
+
+        try:
+            delete_user(supertokens_user_id)
+        except Exception as exc:
+            logger.error("Failed to delete SuperTokens user %s: %s", supertokens_user_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail='Failed to delete user account'
+            )
+
+        user.email = f"deleted_{user.id}@deleted.local"
+        user.handle = f"deleted_{user.id}"
+        user.profile_picture_url = None
+        user.deleted_at = datetime.datetime.now(datetime.timezone.utc)
+        user.anonymized_at = datetime.datetime.now(datetime.timezone.utc)
+
+        db.commit()
+
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content={
+                'message': 'User account deleted successfully'
+            }
+        )
+    
+    except Exception as exc:
+        logger.error("Error deleting user data for user %s: %s", user.id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail='Failed to delete user data'
+        )

--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -299,6 +299,8 @@ async def delete_account(
                 detail='Failed to delete user account'
             )
 
+        email = user.email
+
         user.email = f"deleted_{user.id}@deleted.local"
         user.supertokens_user_id = f"deleted_{user.supertokens_user_id}"
         user.handle = f"deleted_{user.id}"
@@ -307,6 +309,13 @@ async def delete_account(
         user.anonymized_at = datetime.datetime.now(datetime.timezone.utc)
 
         db.commit()
+
+        EmailService.send_email(    
+            to_mail=email,
+            subject="Your DailySpeakUp account has been deleted",
+            template="confirm_account_deletion",
+            message=""
+        )
 
         response = JSONResponse(
             status_code=status.HTTP_200_OK,

--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from ..deps import get_session, get_s3_service
 from ...db import get_db
 from ...schemas import UserResponse, UserCreate, MonthlyUserVideosResponse, VideoInfo, FriendsListResponse, FriendInfo
-from ...models import User, Friendship, UserStreak, Speech, UserDevice, UserInterest, Rating, Ban, Report
+from ...models import User, Friendship, UserStreak, Speech, UserDevice, UserInterest, Rating, Ban, Report, UserRole
 from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.asyncio import delete_user
 
@@ -276,7 +276,7 @@ async def delete_account(
 
     # Delete user-related data here (e.g., speeches, friendships, etc.)
     try:
-        speeches.delete()
+        speeches.delete(synchronize_session=False)
 
         db.query(Speech).filter(Speech.deleted_by == user.id).update({Speech.deleted_by: None})
 
@@ -309,12 +309,18 @@ async def delete_account(
 
         email = user.email
 
-        user.email = f"deleted_{user.id}@deleted.local"
-        user.supertokens_user_id = f"deleted_{user.supertokens_user_id}"
-        user.handle = f"deleted_{user.id}"
-        user.profile_picture_url = None
-        user.deleted_at = datetime.datetime.now(datetime.timezone.utc)
-        user.anonymized_at = datetime.datetime.now(datetime.timezone.utc)
+        # Soft delete for admins/moderators, hard delete for regular users
+        # Admins and moderators should remain for moderation purposes in Bans and Reports
+        if user.role == UserRole.USER:
+            db.delete(user)
+
+        else:
+            user.email = f"deleted_{user.id}@deleted.local"
+            user.supertokens_user_id = f"deleted_{user.supertokens_user_id}"
+            user.handle = f"deleted_{user.id}"
+            user.profile_picture_url = None
+            user.deleted_at = datetime.datetime.now(datetime.timezone.utc)
+            user.anonymized_at = datetime.datetime.now(datetime.timezone.utc)
 
         db.commit()
 

--- a/backend/src/api/v1/user.py
+++ b/backend/src/api/v1/user.py
@@ -245,7 +245,8 @@ async def get_friends_list(
 @router.delete('/delete', response_class=JSONResponse)
 async def delete_account(
     db: Session = Depends(get_db),
-    session: SessionContainer = Depends(get_session)
+    session: SessionContainer = Depends(get_session),
+    s3_service: S3SecureService = Depends(get_s3_service)
 ):
     supertokens_user_id = session.get_user_id()
 
@@ -259,15 +260,22 @@ async def delete_account(
             detail='User not found'
         )
     
-    # ------------------------------------ #
-    # Delete user's videos and pfp from S3 #
-    # ------------------------------------ #
-    
+    speeches = db.query(Speech).filter(Speech.user_id == user.id)
+    speeches_ids = [speech.id for speech in speeches.all()]
+    speech_ids_str = [str(sid) for sid in speeches_ids]
+
+    # Delete from S3
+    try:
+        s3_service.delete_videos(str(user.id), speech_ids_str)
+        s3_service.delete_profile_photo(str(user.id))
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail='Failed to delete user files on S3'
+        )   
 
     # Delete user-related data here (e.g., speeches, friendships, etc.)
     try:
-        speeches = db.query(Speech).filter(Speech.user_id == user.id)
-        speeches_ids = [speech.id for speech in speeches.all()]
         speeches.delete()
 
         db.query(Speech).filter(Speech.deleted_by == user.id).update({Speech.deleted_by: None})

--- a/backend/src/db_mock_seeder.py
+++ b/backend/src/db_mock_seeder.py
@@ -211,7 +211,7 @@ def seed_friendships_for_non_mock_user():
     fake = Faker()
     with Session(engine) as session:
         users = session.query(User).all()
-        non_mock_user = session.query(User).filter(~User.supertokens_user_id.like('mock-%')).first()
+        non_mock_user = session.query(User).filter(~User.supertokens_user_id.like('mock-%'), ~User.supertokens_user_id.like('deleted_%')).first()
         existing_count = session.query(Friendship).filter(
             (Friendship.user_id1 == non_mock_user.id) | (Friendship.user_id2 == non_mock_user.id)
         ).count() if non_mock_user else 0

--- a/backend/src/services/email_impl/celery_tasks.py
+++ b/backend/src/services/email_impl/celery_tasks.py
@@ -13,7 +13,7 @@ def send_email_task(to_mail : str, subject : str, body_text : str, template : st
         to_mail (str): Receiver's email address.
         subject (str): Subject of the email.
         body_text (str): Body text of the email.
-        template (str): Template type ('welcome', 'basic_message', or 'passwordless_login').
+        template (str): Template type ('welcome', 'basic_message',  'passwordless_login', 'confirm_account_deletion').
         code (str, optional): Code for passwordless login.
         magic_link (str, optional): Magic link for passwordless login.
     """

--- a/backend/src/services/email_impl/email_template.py
+++ b/backend/src/services/email_impl/email_template.py
@@ -141,6 +141,196 @@ def passwordless_login():
 </html>
 """
 
+def delete_account_message():
+    return """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Account Deletion Confirmation</title>
+  <style>
+    /* Reset */
+    body, table, td, a {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+    table, td {
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      outline: none;
+      text-decoration: none;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      width: 100% !important;
+      height: 100% !important;
+      background-color: #f1f6fb;
+      font-family: Arial, Helvetica, sans-serif;
+      color: #1f2d3d;
+    }
+
+    /* Container */
+    .email-container {
+      max-width: 600px;
+      margin: 0 auto;
+      background-color: #ffffff;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    /* Header */
+    .header {
+      background-color: #0d6efd;
+      padding: 24px;
+      text-align: center;
+    }
+
+    .logo-placeholder {
+      width: 11.5vh;
+      height: 11.5vh;
+      background-color: #ffffff;
+      color: #0d6efd;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      font-size: 14px;
+      border-radius: 20%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+
+    /* Content */
+    .content {
+      padding: 32px 24px;
+    }
+
+    .content h1 {
+      font-size: 22px;
+      margin: 0 0 16px 0;
+      color: #0d6efd;
+    }
+
+    .content p {
+      font-size: 15px;
+      line-height: 1.6;
+      margin: 0 0 16px 0;
+    }
+
+    .info-box {
+      background-color: #f1f6fb;
+      border-left: 4px solid #0d6efd;
+      padding: 16px;
+      margin: 24px 0;
+      font-size: 14px;
+    }
+
+    /* Button */
+    .button-wrapper {
+      text-align: center;
+      margin: 32px 0 8px;
+    }
+
+    .button {
+      background-color: #0d6efd;
+      color: #ffffff;
+      text-decoration: none;
+      padding: 12px 24px;
+      border-radius: 6px;
+      font-size: 15px;
+      display: inline-block;
+    }
+
+    /* Footer */
+    .footer {
+      background-color: #f1f6fb;
+      padding: 20px 24px;
+      font-size: 12px;
+      color: #6c757d;
+      text-align: center;
+    }
+
+    .footer a {
+      color: #0d6efd;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+      <td align="center">
+        <table class="email-container" width="100%" cellpadding="0" cellspacing="0">
+
+          <!-- Header -->
+          <tr>
+            <td class="header">
+              <div class="logo-placeholder">
+                <img src="https://i.ibb.co/7JSrmZyf/favicon.png" style="height: 10vh;">
+              </div>
+            </td>
+          </tr>
+
+          <!-- Content -->
+          <tr>
+            <td class="content">
+              <h1>Account Deletion Requested</h1>
+
+              <p>Hello,</p>
+
+              <p>
+                We’re writing to confirm that a request has been made to delete your
+                <strong>Daily Speak Up</strong> account.
+              </p>
+
+              <div class="info-box">
+                <strong>What happens next?</strong><br />
+                Your account and all associated data will be permanently deleted
+                within <strong>24 hours</strong>.
+              </div>
+
+             
+              <p>
+                Thank you for being part of Daily Speak Up.
+              </p>
+
+              <p>
+                — The Daily Speak Up Team
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td class="footer">
+              <p>
+                This email was sent automatically. Please do not reply.
+              </p>
+              <p>
+                © 2026 Daily Speak Up
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>
+
+    """
+
 def welcome_message():
     return """
 <!DOCTYPE html>

--- a/backend/src/services/email_impl/sender.py
+++ b/backend/src/services/email_impl/sender.py
@@ -1,5 +1,5 @@
 from ...api.config import get_settings
-from .email_template import basic_html_message, place_holder, welcome_message, passwordless_login
+from .email_template import basic_html_message, place_holder, welcome_message, passwordless_login, delete_account_message
 import resend
 
 class ResendEmailSender:
@@ -28,6 +28,8 @@ class ResendEmailSender:
             html = welcome_message()
         elif template == 'basic_message':
             html = basic_html_message().replace(place_holder(), body_text)
+        elif template == 'confirm_account_deletion':
+            html = delete_account_message()
         elif template == 'passwordless_login':
             html = passwordless_login()
             if code:

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -8,7 +8,7 @@ class EmailService:
     @staticmethod
     def send_email(to_mail: str, subject: str, 
                    message: str = 'Welcome to DailySpeakUp!',
-                   template: Literal['basic_message', 'welcome', 'passwordless_login'] = 'welcome',
+                   template: Literal['basic_message', 'welcome', 'passwordless_login', 'confirm_account_deletion'] = 'welcome',
                    code: Optional[str] = None,
                    magic_link: Optional[str] = None) -> None:
         """

--- a/backend/src/services/s3_secure_service.py
+++ b/backend/src/services/s3_secure_service.py
@@ -1,6 +1,6 @@
 import boto3
 from botocore.client import Config
-from typing import Dict, Any
+from typing import Dict, Any, List
 from io import BytesIO
 
 class S3SecureService:
@@ -178,3 +178,26 @@ class S3SecureService:
             return s3_key
         except Exception as e:
             raise Exception(f"Failed to upload file to S3: {str(e)}")
+    
+    def delete_videos(self, user_id: str, video_ids: List[str]) -> None:
+        """
+        Deletes a file from S3 given its key.
+        :param video_ids: The list of video IDs of the files to delete
+        """
+        try:
+            for video_id in video_ids:
+                s3_key = f"video/{user_id}/{video_id}.mp4"
+                self.s3_client.delete_object(Bucket=self.bucket, Key=s3_key)
+        except Exception as e:
+            raise Exception(f"Failed to delete videos from S3: {str(e)}")
+    
+    def delete_profile_photo(self, user_id: str) -> None:
+        """
+        Deletes the profile photo of a user from S3.
+        """
+        try:
+            for extension in ['png', 'jpg']:
+                s3_key = f"photo/{user_id}.{extension}"
+                self.s3_client.delete_object(Bucket=self.bucket, Key=s3_key)
+        except Exception as e:
+            raise Exception(f"Failed to delete profile photo from S3: {str(e)}")

--- a/frontend/src/components/Logout.vue
+++ b/frontend/src/components/Logout.vue
@@ -1,5 +1,5 @@
 <template>
-    <Button label="Log out" icon="pi pi-sign-out" severity="warn" @click="handleLogout" :loading="loading" />
+    <Button label="Odjava" icon="pi pi-sign-out" severity="warn" @click="handleLogout" :loading="loading" />
 </template>
 
 <script>

--- a/frontend/src/components/SettingsDrawer.vue
+++ b/frontend/src/components/SettingsDrawer.vue
@@ -35,8 +35,24 @@
             label: 'Izbriši',
             severity: 'danger'
         },
-        accept: () => {
-            console.log('Account deletion confirmed');
+        accept: async () => {
+            try {
+                const response = await fetch(`${import.meta.env.VITE_API_DOMAIN || window.ENV?.VITE_API_DOMAIN || 'http://localhost:8123'}/api/v1/user/delete`, {
+                    method: 'DELETE',
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                });
+
+                if (response.ok) {
+                    window.location.reload();
+                } else {
+                    console.error('Failed to delete account');
+                }
+            } catch (error) {
+                console.error('Error deleting account:', error);
+            }
         },
         reject: () => {
             console.log('Account deletion rejected');

--- a/frontend/src/components/SettingsDrawer.vue
+++ b/frontend/src/components/SettingsDrawer.vue
@@ -115,7 +115,7 @@
                 
                 <div class="flex flex-row w-full justify-between mt-10">
                     <Logout class="mt-10 w-[45%]" />
-                    <Button @click="confirm_account_deletion()" label="Delete account" severity="danger" icon="pi pi-trash" class="mt-10 w-[45%]" />
+                    <Button @click="confirm_account_deletion()" label="Izbriši račun" severity="danger" icon="pi pi-trash" class="mt-10 w-[45%]" />
                 </div>
             </div>
         </Drawer>

--- a/frontend/src/components/SettingsDrawer.vue
+++ b/frontend/src/components/SettingsDrawer.vue
@@ -2,9 +2,11 @@
     import Drawer from 'primevue/drawer';
     import Button from 'primevue/button';
     import Select from 'primevue/select';
+    import { useConfirm } from "primevue/useconfirm";
     import MultiSelect from 'primevue/multiselect';
     import Panel from 'primevue/panel';
     import ToggleSwitch from 'primevue/toggleswitch';
+    import ConfirmDialog from 'primevue/confirmdialog';
     import Login from './LoginModal.vue';
     import Logout from './Logout.vue';
     import User from './User.vue';
@@ -16,6 +18,31 @@
     const selectedLanguage = ref();
     const selectedInterests = ref([]);
     const interests = ref([]);
+    const confirm = useConfirm();
+
+    const confirm_account_deletion = () => {
+        confirm.require({
+        message: 'Jeste li sigurni da želite izbrisati svoj račun? Ova se radnja ne može poništiti.',
+        header: 'Opasna radnja',
+        icon: 'pi pi-exclamation-triangle',
+        rejectLabel: 'Odustani',
+        rejectProps: {
+            label: 'Odustani',
+            severity: 'secondary',
+            outlined: true
+        },
+        acceptProps: {
+            label: 'Izbriši',
+            severity: 'danger'
+        },
+        accept: () => {
+            console.log('Account deletion confirmed');
+        },
+        reject: () => {
+            console.log('Account deletion rejected');
+        }
+    });
+    }
 
     onMounted(async () => {
         try {
@@ -52,6 +79,7 @@
 </script>
 
 <template>
+    <ConfirmDialog></ConfirmDialog>
     <div class="flex justify-center">
         <Drawer v-model:visible="visible" header="Postavke računa" position="left" 
                 :dismissable="false" class="!w-full lg:!w-[40vw]">
@@ -87,7 +115,7 @@
                 
                 <div class="flex flex-row w-full justify-between mt-10">
                     <Logout class="mt-10 w-[45%]" />
-                    <Button label="Delete account" severity="danger" icon="pi pi-trash" class="mt-10 w-[45%]" />
+                    <Button @click="confirm_account_deletion()" label="Delete account" severity="danger" icon="pi pi-trash" class="mt-10 w-[45%]" />
                 </div>
             </div>
         </Drawer>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import './style.css'
 import PrimeVue from 'primevue/config';
 import ToastService from 'primevue/toastservice';
+import ConfirmationService from 'primevue/confirmationservice';
 import Tooltip from 'primevue/tooltip';
 import Lara from '@primeuix/themes/lara';
 import { definePreset } from '@primeuix/themes';
@@ -71,6 +72,8 @@ app.use(PrimeVue, {
 });
 
 app.use(ToastService);
+
+app.use(ConfirmationService);
 
 app.use(router);
 


### PR DESCRIPTION
#96 Implemented account deletion on user's request.

### DONE:
- user's prompted with a confirm dialog
- user's profile picture and speeches saved on S3 are deleted (@EmilPopovic pls provjeris logiku za to jer fkt nisam sig jel to dela)
- user's SuperTokens data is deleted
- user's data in DB is deleted/anonymized
  - DB tables deletion order in this PR:
    1. Bans
    2. Ratings
    3. Reports
    4. Friendships
    5. UserStreaks
    6. UserDevices
    7. UserInterests
  - **deleting from User table**
    - if user has a role USER then they are just deleted from User table of DB
    - if user has either an ADMIN or a MODERATOR role they are anonymized in the User table of DSU DB so they're IDs could still be used in tables Bans (for banned_by attribute) and Reports (for resolved_by attribute)
- when deletion is completed, user is sent an confirmation email

### SIDE QUESTS:
 - adjusted mock DB seeder to ignore deleted non-mock user
 - changed Logout and Delete Account buttons' primary text to Croatian